### PR TITLE
Add completions for Obsidian Callouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@ main.js
 data.json
 scanned_words.txt
 blacklisted_suggestions.txt
+callout_suggestions.json
 latex_commands.json
 wordLists

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import {editorToCodeMirrorState, posFromIndex} from "./editor_helpers";
 import {markerStateField} from "./marker_state_field";
 import {FrontMatter} from "./provider/front_matter_provider";
 import {Latex} from "./provider/latex_provider";
+import {Callout} from "./provider/callout_provider";
 import {SuggestionBlacklist} from "./provider/blacklist";
 
 export default class CompletrPlugin extends Plugin {
@@ -273,6 +274,7 @@ export default class CompletrPlugin extends Plugin {
             WordList.loadFromFiles(this.app.vault, this.settings);
             FileScanner.loadData(this.app.vault);
             Latex.loadCommands(this.app.vault);
+            Callout.loadSuggestions(this.app.vault);
         });
     }
 

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -109,7 +109,7 @@ export default class SuggestionPopup extends EditorSuggest<Suggestion> {
         const replacement = value.replacement;
         const start = typeof value !== "string" && value.overrideStart ? value.overrideStart : this.context.start;
 
-        const endPos = this.context.end;
+        const endPos = value.overrideEnd ?? this.context.end;
         this.context.editor.replaceRange(replacement, start, {
             ...endPos,
             ch: Math.min(endPos.ch, this.context.editor.getLine(endPos.line).length)

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -16,8 +16,9 @@ import {CompletrSettings} from "./settings";
 import {FrontMatter} from "./provider/front_matter_provider";
 import {matchWordBackwards} from "./editor_helpers";
 import {SuggestionBlacklist} from "./provider/blacklist";
+import {Callout} from "./provider/callout_provider";
 
-const PROVIDERS: SuggestionProvider[] = [FrontMatter, Latex, FileScanner, WordList];
+const PROVIDERS: SuggestionProvider[] = [FrontMatter, Latex, FileScanner, WordList, Callout];
 
 export default class SuggestionPopup extends EditorSuggest<Suggestion> {
     /**

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -9,6 +9,7 @@ import {
     EditorSuggest,
     EditorSuggestContext,
     EditorSuggestTriggerInfo,
+    getIcon,
     TFile
 } from "obsidian";
 import SnippetManager from "./snippet_manager";
@@ -103,7 +104,24 @@ export default class SuggestionPopup extends EditorSuggest<Suggestion> {
 
     renderSuggestion(value: Suggestion, el: HTMLElement): void {
         el.addClass("completr-suggestion-item");
-        el.setText(value.displayName);
+        if (value.color != null) {
+            el.style.setProperty("--completr-suggestion-color", value.color);
+        }
+
+        // Add the icon.
+        if (value.icon != null) {
+            const icon = getIcon(value.icon);
+            if (icon != null) {
+                icon.addClass("completr-suggestion-icon");
+                el.appendChild(icon);
+            }
+        }
+
+        // Add the text.
+        const text = el.doc.createElement("div");
+        text.addClass("completr-suggestion-text");
+        text.setText(value.displayName);
+        el.appendChild(text);
     }
 
     selectSuggestion(value: Suggestion, evt: MouseEvent | KeyboardEvent): void {

--- a/src/provider/callout_provider.ts
+++ b/src/provider/callout_provider.ts
@@ -54,8 +54,8 @@ class CalloutSuggestionProvider implements SuggestionProvider {
             return [];
 
         // Generate and return the suggestions.
-        const replaceFoldable = callout.foldable.rawText === '' ? ' ' : callout.foldable.rawText;
         const replaceTitle = callout.title.rawText;
+        const replaceFoldable = untrimEnd(callout.foldable.rawText);
 
         const search = callout.type.text.toLowerCase();
         return this.loadedSuggestions
@@ -100,6 +100,15 @@ class CalloutSuggestionProvider implements SuggestionProvider {
 
 export const Callout = new CalloutSuggestionProvider();
 
+/*
+ * Ensures there is at least one character worth of whitespace at the end of the provided string.
+ */
+function untrimEnd(string: string) {
+    if (string.trimEnd() !== string)
+        return string; // There's already some whitespace at the end.
+
+    return `${string} `;
+}
 
 /*
  * Extract information about the block quote.

--- a/src/provider/callout_provider.ts
+++ b/src/provider/callout_provider.ts
@@ -1,0 +1,225 @@
+import {
+    Suggestion,
+    SuggestionContext,
+    SuggestionProvider
+} from "./provider";
+import {CompletrSettings, intoCompletrPath} from "../settings";
+import {Notice, Vault} from "obsidian";
+import {SuggestionBlacklist} from "./blacklist";
+
+
+const CALLOUT_SUGGESTIONS_FILE = "callout_suggestions.json";
+
+const BLOCKQUOTE_PREFIX_REGEX = /^(?:[ \t]*>[ \t]*)+/;
+const CALLOUT_HEADER_REGEX = /^(\[!?([^\]]*)\])([+-]?)([ \t]*)(.*)$/d; // [!TYPE]- TITLE
+const CALLOUT_HEADER_PARTIAL_REGEX = /^(\[!?([^\]]*))$/d;           // [!TYPE
+
+class CalloutSuggestionProvider implements SuggestionProvider {
+
+    private loadedSuggestions: Suggestion[] = [];
+
+    getSuggestions(context: SuggestionContext, settings: CompletrSettings): Suggestion[] {
+        if (!settings.calloutProviderEnabled)
+            return [];
+
+        const { editor } = context;
+        const lineNumber = context.start.line;
+        const line = editor.getLine(lineNumber);
+
+        // Ensure we're in a block quote.
+        const quote = extractBlockQuotePrefix(line);
+        if (quote == null)
+            return [];
+
+        // Ensure we're the top of this specific block quote.
+        // Example:
+        //   > > >     <-- OK
+        //   > > >     <-- not OK (continuation)
+        //   > >       <-- not OK (continuation of lower-depth block)
+        //   > > >     <-- OK (new block)
+        //
+        const quoteAbove = lineNumber === 0 ? null : extractBlockQuotePrefix(editor.getLine(lineNumber - 1));
+        if (quoteAbove != null && quoteAbove.depth >= quote.depth)
+            return [];
+
+        // Get the callout type.
+        const trimmed = line.substring(quote.chOffset);
+        const callout = extractCalloutHeader(trimmed);
+        if (callout === null)
+            return [];
+
+        // Do nothing if the cursor is outside the callout type area.
+        const cursor = editor.getCursor("from").ch - quote.chOffset;
+        if (cursor < callout.type.start + 1 || cursor > callout.type.end)
+            return [];
+
+        // Generate and return the suggestions.
+        const replaceFoldable = callout.foldable.rawText === '' ? ' ' : callout.foldable.rawText;
+        const replaceTitle = callout.title.rawText;
+
+        const search = callout.type.text.toLowerCase();
+        return this.loadedSuggestions
+            .filter(s => s.displayName.toLowerCase().startsWith(search) || s.replacement.toLowerCase().startsWith(search))
+            .map(suggestion => {
+                return suggestion.derive({
+                    replacement: `[!${suggestion.replacement}]${replaceFoldable}${replaceTitle}`,
+                    overrideEnd: {
+                        line: context.end.line,
+                        ch: line.length,
+                    },
+                    overrideStart: {
+                        line: context.start.line,
+                        ch: quote.chOffset,
+                    }
+                });
+            });
+    }
+
+    async loadSuggestions(vault: Vault) {
+        const path = intoCompletrPath(vault, CALLOUT_SUGGESTIONS_FILE);
+
+        if (!(await vault.adapter.exists(path))) {
+            const defaultCommands = generateDefaulCalloutOptions();
+            await vault.adapter.write(path, JSON.stringify(defaultCommands, null, 2));
+            this.loadedSuggestions = defaultCommands;
+        } else {
+            const data = await vault.adapter.read(path);
+            try {
+                const suggestions: Suggestion[] = (JSON.parse(data) as any[])
+                    .map(obj => typeof obj === "string" ?
+                        Suggestion.fromString(obj) :
+                        new Suggestion(obj.displayName, obj.replacement)
+                    );
+                const invalidsuggestion = suggestions.find(c => c.displayName.includes("\n"));
+                if (invalidsuggestion)
+                    throw new Error("Display name cannot contain a newline: " + invalidsuggestion.displayName);
+
+                this.loadedSuggestions = suggestions;
+            } catch (e) {
+                console.log("Completr callout types parse error:", e.message);
+                new Notice("Failed to parse callout types file " + path + ". Using default suggestions.", 3000);
+                this.loadedSuggestions = generateDefaulCalloutOptions();
+            }
+        }
+
+        this.loadedSuggestions = SuggestionBlacklist.filter(this.loadedSuggestions);
+    }
+}
+
+export const Callout = new CalloutSuggestionProvider();
+
+
+/*
+ * Extract information about the block quote.
+ */
+function extractBlockQuotePrefix(line: string): { depth: number, chOffset: number, text: string } | null {
+    const matches = BLOCKQUOTE_PREFIX_REGEX.exec(line);
+    if (matches == null)
+        return null;
+
+    const depth = /* the number of ">" chars */
+        matches[0].length -
+        matches[0].replaceAll(">", "").length;
+
+    return {
+        chOffset: matches[0].length,
+        text: matches[0],
+        depth,
+    }
+}
+
+interface CalloutHeader {
+    type: { start: number, end: number, text: string, rawText: string },
+    foldable: { start: number, end: number, text: string, rawText: string },
+    title: { start: number, end: number, text: string, rawText: string },
+}
+
+/*
+ * Extract information from the callout header.
+ * This assumes that `line` had the blockquote prefix stripped.
+ */
+function extractCalloutHeader(line: string): CalloutHeader | null {
+    const result: CalloutHeader = {
+        type: {
+            start: -1,
+            end: -1,
+            text: '',
+            rawText: '',
+        },
+        foldable: {
+            start: -1,
+            end: -1,
+            text: '',
+            rawText: '',
+        },
+        title: {
+            start: -1,
+            end: -1,
+            text: '',
+            rawText: '',
+        }
+    };
+
+    // Try parsing the full header.
+    let matches = CALLOUT_HEADER_REGEX.exec(line);
+    if (matches !== null) {
+        [result.type.start, result.type.end] = matches.indices[1];
+        result.type.rawText = matches[1];
+        result.type.text = matches[2].trim();
+
+        [result.foldable.start, result.foldable.end] = matches.indices[3];
+        result.foldable.rawText = matches[3] + matches[4];
+        result.foldable.text = result.foldable.rawText.trim();
+
+        [result.title.start, result.title.end] = matches.indices[5];
+        result.title.rawText = matches[5];
+        result.title.text = matches[5].trim();
+        return result;
+    }
+
+    // Try parsing the partial header.
+    matches = CALLOUT_HEADER_PARTIAL_REGEX.exec(line);
+    if (matches !== null) {
+        [result.type.start, result.type.end] = matches.indices[1];
+        result.type.rawText = matches[1];
+        result.type.text = matches[2].trim();
+        return result;
+    }
+
+    return null;
+}
+
+/*
+ * Generates the default callout suggestions. This is a method to avoid any unnecessary initialization
+ */
+function generateDefaulCalloutOptions(): Suggestion[] {
+    return [
+        new Suggestion("Note", "note"),
+        new Suggestion("Summary", "summary"),
+        new Suggestion("Info", "info"),
+        new Suggestion("Tip", "tip"),
+        new Suggestion("Hint", "hint"),
+        new Suggestion("Example", "example"),
+        new Suggestion("Quote", "quote"),
+        new Suggestion("Important", "important"),
+        new Suggestion("Warning", "warning"),
+        new Suggestion("Success", "success"),
+        new Suggestion("Error", "error"),
+        new Suggestion("To-Do", "todo"),
+        new Suggestion("Check", "check"),
+        new Suggestion("Done", "done"),
+        new Suggestion("Question", "question"),
+        new Suggestion("Caution", "caution"),
+        new Suggestion("Attention", "attention"),
+        new Suggestion("Failure", "failure"),
+        new Suggestion("Fail", "fail"),
+        new Suggestion("Missing", "missing"),
+        new Suggestion("Danger", "danger"),
+        new Suggestion("Bug", "bug"),
+        new Suggestion("Help", "Help"),
+        new Suggestion("Abstract", "abstract"),
+        new Suggestion("Cite", "cite"),
+        new Suggestion("TL;DR", "tldr"),
+        new Suggestion("FAQ", "faq"),
+    ];
+}

--- a/src/provider/provider.ts
+++ b/src/provider/provider.ts
@@ -6,11 +6,13 @@ export class Suggestion {
     displayName: string;
     replacement: string;
     overrideStart?: EditorPosition;
+    overrideEnd?: EditorPosition;
 
-    constructor(displayName: string, replacement: string, overrideStart?: EditorPosition) {
+    constructor(displayName: string, replacement: string, overrideStart?: EditorPosition, overrideEnd?: EditorPosition) {
         this.displayName = displayName;
         this.replacement = replacement;
         this.overrideStart = overrideStart;
+        this.overrideEnd = overrideEnd;
     }
 
     static fromString(suggestion: string, overrideStart?: EditorPosition): Suggestion {
@@ -19,6 +21,17 @@ export class Suggestion {
 
     getDisplayNameLowerCase(lowerCase: boolean): string {
         return maybeLowerCase(this.displayName, lowerCase);
+    }
+
+    derive(options: Partial<typeof this>) {
+        const derived = new Suggestion(
+            options.displayName ?? this.displayName,
+            options.replacement ?? this.replacement,
+            options.overrideStart ?? this.overrideStart,
+            options.overrideEnd ?? this.overrideEnd,
+        );
+
+        return derived;
     }
 }
 

--- a/src/provider/provider.ts
+++ b/src/provider/provider.ts
@@ -7,12 +7,19 @@ export class Suggestion {
     replacement: string;
     overrideStart?: EditorPosition;
     overrideEnd?: EditorPosition;
+    icon?: string;
+    color?: string;
 
-    constructor(displayName: string, replacement: string, overrideStart?: EditorPosition, overrideEnd?: EditorPosition) {
+    constructor(displayName: string, replacement: string, overrideStart?: EditorPosition, overrideEnd?: EditorPosition, opts?: {
+        icon?: string,
+        color?: string,
+    }) {
         this.displayName = displayName;
         this.replacement = replacement;
         this.overrideStart = overrideStart;
         this.overrideEnd = overrideEnd;
+        this.icon = opts?.icon;
+        this.color = opts?.color;
     }
 
     static fromString(suggestion: string, overrideStart?: EditorPosition): Suggestion {
@@ -29,6 +36,10 @@ export class Suggestion {
             options.replacement ?? this.replacement,
             options.overrideStart ?? this.overrideStart,
             options.overrideEnd ?? this.overrideEnd,
+            {
+                icon: options.icon ?? this.icon,
+                color: options.color ?? this.color,
+            }
         );
 
         return derived;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -22,7 +22,8 @@ export interface CompletrSettings {
     wordListProviderEnabled: boolean,
     frontMatterProviderEnabled: boolean,
     frontMatterTagAppendSuffix: boolean,
-    frontMatterIgnoreCase: boolean
+    frontMatterIgnoreCase: boolean,
+    calloutProviderEnabled: boolean,
 }
 
 export const DEFAULT_SETTINGS: CompletrSettings = {
@@ -41,7 +42,8 @@ export const DEFAULT_SETTINGS: CompletrSettings = {
     wordListProviderEnabled: true,
     frontMatterProviderEnabled: true,
     frontMatterTagAppendSuffix: true,
-    frontMatterIgnoreCase: true
+    frontMatterIgnoreCase: true,
+    calloutProviderEnabled: true,
 }
 
 export function intoCompletrPath(vault: Vault, ...path: string[]): string {

--- a/src/settings_tab.ts
+++ b/src/settings_tab.ts
@@ -302,6 +302,12 @@ export default class CompletrSettingsTab extends PluginSettingTab {
                     ).settingEl.addClass("completr-settings-list-item");
             }
         });
+
+        new Setting(containerEl)
+            .setName("Callout provider")
+            .setHeading();
+
+        this.createEnabledSetting("calloutProviderEnabled", "Whether or not the callout provider is enabled", containerEl);
     }
 
     private async reloadWords() {

--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,31 @@
+body {
+    --completr-suggestion-icon-height: 14px;
+}
+
 .completr-suggestion-item {
     padding: 5px 10px 5px 10px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+
+    display: flex;
+    align-items: center;
+}
+
+.completr-suggestion-item > * {
+    display: inline-block;
+}
+
+.completr-suggestion-icon {
+    height: var(--completr-suggestion-icon-height);
+    min-height: var(--completr-suggestion-icon-height);
+    max-height: var(--completr-suggestion-icon-height);
+
+    margin-right: 0.5ch;
+    color: var(--completr-suggestion-color);
+}
+
+.completr-suggestion-text {
 }
 
 .completr-suggestion-placeholder {


### PR DESCRIPTION
Adds completion/suggestion support for Obsidian [callouts](https://help.obsidian.md/How+to/Use+callouts).

<img width="318" alt="image" src="https://user-images.githubusercontent.com/32112321/204982624-ab2f0f69-da84-450d-9d9c-d34c1df96034.png">

- Only triggers when changing the type of a callout.
   ```
   > [!TYPE] Title
      ~~~~~ <-- only triggers for these characters
   ```

- Will show (and correctly autocomplete) when a callout is likely to be created.
   ```
   > [_
      ~ <-- will trigger here
   ```

- Moves cursor in the ideal place to type the title.
   ```
   > [!TY_] _
         |  ~ <-- cursor will move here
         ~ <-- complete from here
   ```

- Correctly handles nested callouts.


## Reviewer Note

Each commit is a distinct change, and is easier to review one-by-one instead of as a whole.