### PR TITLE
Use Callout Manager plugin as source for callouts.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
 	"name": "obsidian-completr",
-	"version": "3.0.1",
+	"version": "3.1.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-completr",
-			"version": "3.0.1",
+			"version": "3.1.3",
 			"license": "MIT",
+			"dependencies": {
+				"obsidian-callout-manager": "^1.0.2-alpha1"
+			},
 			"devDependencies": {
 				"@codemirror/state": "^6.1.2",
 				"@types/node": "^16.11.6",
@@ -24,14 +27,12 @@
 		"node_modules/@codemirror/state": {
 			"version": "6.1.2",
 			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.1.2.tgz",
-			"integrity": "sha512-Mxff85Hp5va+zuj+H748KbubXjrinX/k28lj43H14T2D0+4kuvEFIEIO7hCEcvBT8ubZyIelt9yGOjj2MWOEQA==",
-			"dev": true
+			"integrity": "sha512-Mxff85Hp5va+zuj+H748KbubXjrinX/k28lj43H14T2D0+4kuvEFIEIO7hCEcvBT8ubZyIelt9yGOjj2MWOEQA=="
 		},
 		"node_modules/@codemirror/view": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.1.0.tgz",
 			"integrity": "sha512-T5QTuzwxbQ+KnZzz1ef3e3QCNH2qMdTmQhA4tbsK62lJGyCMZHSaSAJpFAr67c6Wl34IBgx2M7ue6WxJpWPOPg==",
-			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@codemirror/state": "^6.0.0",
@@ -163,7 +164,6 @@
 			"version": "0.0.108",
 			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.108.tgz",
 			"integrity": "sha512-3FGFcus0P7C2UOGCNUVENqObEb4SFk+S8Dnxq7K6aIsLVs/vDtlangl3PEO0ykaKXyK56swVF6Nho7VsA44uhw==",
-			"dev": true,
 			"dependencies": {
 				"@types/tern": "*"
 			}
@@ -171,8 +171,7 @@
 		"node_modules/@types/estree": {
 			"version": "0.0.50",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
-			"dev": true
+			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.11",
@@ -190,7 +189,6 @@
 			"version": "0.23.4",
 			"resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.4.tgz",
 			"integrity": "sha512-JAUw1iXGO1qaWwEOzxTKJZ/5JxVeON9kvGZ/osgZaJImBnyjyn0cjovPsf6FNLmyGY8Vw9DoXZCMlfMkMwHRWg==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "*"
 			}
@@ -1627,7 +1625,6 @@
 			"version": "2.29.4",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
 			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-			"dev": true,
 			"engines": {
 				"node": "*"
 			}
@@ -1657,6 +1654,54 @@
 			"peerDependencies": {
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.0.0"
+			}
+		},
+		"node_modules/obsidian-callout-manager": {
+			"version": "1.0.2-alpha1",
+			"resolved": "https://registry.npmjs.org/obsidian-callout-manager/-/obsidian-callout-manager-1.0.2-alpha1.tgz",
+			"integrity": "sha512-aAFxpQ8rWSgCMOTKl7iYV2Zh2ecEjohxXJUzCtvnMak76dniTKvr+hp24hfyUC/S7KydsF5WqyL1I4/WsvdOSQ==",
+			"dependencies": {
+				"obsidian-extra": "^0.1.3"
+			}
+		},
+		"node_modules/obsidian-callout-manager/node_modules/@types/node": {
+			"version": "18.14.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.2.tgz",
+			"integrity": "sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA=="
+		},
+		"node_modules/obsidian-callout-manager/node_modules/obsidian": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.1.1.tgz",
+			"integrity": "sha512-GcxhsHNkPEkwHEjeyitfYNBcQuYGeAHFs1pEpZIv0CnzSfui8p8bPLm2YKLgcg20B764770B1sYGtxCvk9ptxg==",
+			"peer": true,
+			"dependencies": {
+				"@types/codemirror": "0.0.108",
+				"moment": "2.29.4"
+			},
+			"peerDependencies": {
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.0.0"
+			}
+		},
+		"node_modules/obsidian-callout-manager/node_modules/obsidian-extra": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/obsidian-extra/-/obsidian-extra-0.1.3.tgz",
+			"integrity": "sha512-bq44O33YScneAZG5svlm3O3qGsNtbsyqftLCaH4yr8vHlLIIdfAiGnzRxO9PneK2iZVvED6GMoSDsgru+LYbqA==",
+			"dependencies": {
+				"@types/node": "^18.13.0"
+			},
+			"peerDependencies": {
+				"obsidian": ">=1.0.0",
+				"obsidian-undocumented": "^0.1.3"
+			}
+		},
+		"node_modules/obsidian-callout-manager/node_modules/obsidian-undocumented": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/obsidian-undocumented/-/obsidian-undocumented-0.1.3.tgz",
+			"integrity": "sha512-JjJuY8aepETPMumGwleq/lVa7gM7yfQxbVbk83sim21wZv6oo2v2GA/KZf62pO5Jri37Lj6XWVlqnxQKSQ/9Hw==",
+			"peer": true,
+			"peerDependencies": {
+				"obsidian": ">=1.0.0"
 			}
 		},
 		"node_modules/once": {
@@ -1939,7 +1984,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
 			"integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==",
-			"dev": true,
 			"peer": true
 		},
 		"node_modules/supports-color": {
@@ -2061,7 +2105,6 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.4.tgz",
 			"integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw==",
-			"dev": true,
 			"peer": true
 		},
 		"node_modules/which": {
@@ -2108,14 +2151,12 @@
 		"@codemirror/state": {
 			"version": "6.1.2",
 			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.1.2.tgz",
-			"integrity": "sha512-Mxff85Hp5va+zuj+H748KbubXjrinX/k28lj43H14T2D0+4kuvEFIEIO7hCEcvBT8ubZyIelt9yGOjj2MWOEQA==",
-			"dev": true
+			"integrity": "sha512-Mxff85Hp5va+zuj+H748KbubXjrinX/k28lj43H14T2D0+4kuvEFIEIO7hCEcvBT8ubZyIelt9yGOjj2MWOEQA=="
 		},
 		"@codemirror/view": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.1.0.tgz",
 			"integrity": "sha512-T5QTuzwxbQ+KnZzz1ef3e3QCNH2qMdTmQhA4tbsK62lJGyCMZHSaSAJpFAr67c6Wl34IBgx2M7ue6WxJpWPOPg==",
-			"dev": true,
 			"peer": true,
 			"requires": {
 				"@codemirror/state": "^6.0.0",
@@ -2213,7 +2254,6 @@
 			"version": "0.0.108",
 			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.108.tgz",
 			"integrity": "sha512-3FGFcus0P7C2UOGCNUVENqObEb4SFk+S8Dnxq7K6aIsLVs/vDtlangl3PEO0ykaKXyK56swVF6Nho7VsA44uhw==",
-			"dev": true,
 			"requires": {
 				"@types/tern": "*"
 			}
@@ -2221,8 +2261,7 @@
 		"@types/estree": {
 			"version": "0.0.50",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
-			"dev": true
+			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
 		},
 		"@types/json-schema": {
 			"version": "7.0.11",
@@ -2240,7 +2279,6 @@
 			"version": "0.23.4",
 			"resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.4.tgz",
 			"integrity": "sha512-JAUw1iXGO1qaWwEOzxTKJZ/5JxVeON9kvGZ/osgZaJImBnyjyn0cjovPsf6FNLmyGY8Vw9DoXZCMlfMkMwHRWg==",
-			"dev": true,
 			"requires": {
 				"@types/estree": "*"
 			}
@@ -3198,8 +3236,7 @@
 		"moment": {
 			"version": "2.29.4",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-			"dev": true
+			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
 		},
 		"ms": {
 			"version": "2.1.2",
@@ -3222,6 +3259,46 @@
 			"requires": {
 				"@types/codemirror": "0.0.108",
 				"moment": "2.29.4"
+			}
+		},
+		"obsidian-callout-manager": {
+			"version": "1.0.2-alpha1",
+			"resolved": "https://registry.npmjs.org/obsidian-callout-manager/-/obsidian-callout-manager-1.0.2-alpha1.tgz",
+			"integrity": "sha512-aAFxpQ8rWSgCMOTKl7iYV2Zh2ecEjohxXJUzCtvnMak76dniTKvr+hp24hfyUC/S7KydsF5WqyL1I4/WsvdOSQ==",
+			"requires": {
+				"obsidian-extra": "^0.1.3"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "18.14.2",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.2.tgz",
+					"integrity": "sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA=="
+				},
+				"obsidian": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.1.1.tgz",
+					"integrity": "sha512-GcxhsHNkPEkwHEjeyitfYNBcQuYGeAHFs1pEpZIv0CnzSfui8p8bPLm2YKLgcg20B764770B1sYGtxCvk9ptxg==",
+					"peer": true,
+					"requires": {
+						"@types/codemirror": "0.0.108",
+						"moment": "2.29.4"
+					}
+				},
+				"obsidian-extra": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/obsidian-extra/-/obsidian-extra-0.1.3.tgz",
+					"integrity": "sha512-bq44O33YScneAZG5svlm3O3qGsNtbsyqftLCaH4yr8vHlLIIdfAiGnzRxO9PneK2iZVvED6GMoSDsgru+LYbqA==",
+					"requires": {
+						"@types/node": "^18.13.0"
+					}
+				},
+				"obsidian-undocumented": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/obsidian-undocumented/-/obsidian-undocumented-0.1.3.tgz",
+					"integrity": "sha512-JjJuY8aepETPMumGwleq/lVa7gM7yfQxbVbk83sim21wZv6oo2v2GA/KZf62pO5Jri37Lj6XWVlqnxQKSQ/9Hw==",
+					"peer": true,
+					"requires": {}
+				}
 			}
 		},
 		"once": {
@@ -3403,7 +3480,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
 			"integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==",
-			"dev": true,
 			"peer": true
 		},
 		"supports-color": {
@@ -3499,7 +3575,6 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.4.tgz",
 			"integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw==",
-			"dev": true,
 			"peer": true
 		},
 		"which": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
 		"typescript": "4.8.4"
 	},
 	"dependencies": {
-		"obsidian-callout-manager": "^1.0.1"
+		"obsidian-callout-manager": "^1.0.2-alpha1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -11,15 +11,18 @@
 	"author": "tth05",
 	"license": "MIT",
 	"devDependencies": {
+		"@codemirror/state": "^6.1.2",
 		"@types/node": "^16.11.6",
 		"@typescript-eslint/eslint-plugin": "^5.30.7",
 		"@typescript-eslint/parser": "^5.30.7",
 		"builtin-modules": "^3.3.0",
 		"esbuild": "^0.15.11",
-        "tslib": "2.4.0",
-        "typescript": "4.8.4",
-        "@codemirror/state": "^6.1.2",
-        "obsidian": "^0.16.3",
-        "jschardet": "^3.0.0"
-    }
+		"jschardet": "^3.0.0",
+		"obsidian": "^0.16.3",
+		"tslib": "2.4.0",
+		"typescript": "4.8.4"
+	},
+	"dependencies": {
+		"obsidian-callout-manager": "^1.0.1"
+	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -342,7 +342,7 @@ export default class CompletrPlugin extends Plugin {
             WordList.loadFromFiles(this.app.vault, this.settings);
             FileScanner.loadData(this.app.vault);
             Latex.loadCommands(this.app.vault);
-            Callout.loadSuggestions(this.app.vault);
+            Callout.loadSuggestions(this.app.vault, this);
         });
     }
 

--- a/src/provider/callout_provider.ts
+++ b/src/provider/callout_provider.ts
@@ -120,8 +120,14 @@ class CalloutSuggestionProvider implements SuggestionProvider {
     protected async loadSuggestionsUsingCalloutManager() {
         const api = await getApi();
 
-        this.loadedSuggestions = api.getCallouts()
-            .map(({id, icon, color}) => newSuggestion(id, id, icon, `rgb(${color})`))
+        this.loadedSuggestions = Array.from(api.getCallouts())
+            .sort(({id: a}, {id: b}) => a.localeCompare(b))
+            .map(callout => newSuggestion(
+                api.getTitle(callout),
+                callout.id,
+                callout.icon,
+                `rgb(${callout.color})`,
+            ));
     }
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,11 @@ export const enum WordInsertionMode {
     IGNORE_CASE_APPEND = "Ignore-Case & Append"
 }
 
+export const enum CalloutProviderSource {
+    COMPLETR = "Completr",
+    CALLOUT_MANAGER = "Callout Manager",
+}
+
 export interface CompletrSettings {
     characterRegex: string,
     maxLookBackDistance: number,
@@ -26,6 +31,7 @@ export interface CompletrSettings {
     frontMatterTagAppendSuffix: boolean,
     frontMatterIgnoreCase: boolean,
     calloutProviderEnabled: boolean,
+    calloutProviderSource: CalloutProviderSource,
 }
 
 export const DEFAULT_SETTINGS: CompletrSettings = {
@@ -48,6 +54,7 @@ export const DEFAULT_SETTINGS: CompletrSettings = {
     frontMatterTagAppendSuffix: true,
     frontMatterIgnoreCase: true,
     calloutProviderEnabled: true,
+    calloutProviderSource: CalloutProviderSource.COMPLETR,
 }
 
 export function intoCompletrPath(vault: Vault, ...path: string[]): string {

--- a/src/settings_tab.ts
+++ b/src/settings_tab.ts
@@ -1,8 +1,9 @@
 import { App, ButtonComponent, Modal, Notice, PluginSettingTab, Setting } from "obsidian";
+import {isInstalled as isCalloutManagerInstalled} from "obsidian-callout-manager";
 import CompletrPlugin from "./main";
 import { FileScanner } from "./provider/scanner_provider";
 import { WordList } from "./provider/word_list_provider";
-import { CompletrSettings, WordInsertionMode } from "./settings";
+import { CalloutProviderSource, CompletrSettings, WordInsertionMode } from "./settings";
 import { TextDecoder } from "util";
 import { detect } from "jschardet";
 
@@ -328,6 +329,24 @@ export default class CompletrSettingsTab extends PluginSettingTab {
             .setHeading();
 
         this.createEnabledSetting("calloutProviderEnabled", "Whether or not the callout provider is enabled", containerEl);
+        new Setting(containerEl)
+            .setName("Source")
+            .setDesc("Where callout suggestions come from.")
+            .addDropdown(component => {
+                component.addOption("Completr", CalloutProviderSource.COMPLETR)
+                    .setValue(CalloutProviderSource.COMPLETR) // Default option.
+                    .onChange(async (value) => {
+                        this.plugin.settings.calloutProviderSource = value as CalloutProviderSource;
+                        await this.plugin.saveSettings();
+                    });
+
+                if (isCalloutManagerInstalled()) {
+                    component.addOption("Callout Manager", CalloutProviderSource.CALLOUT_MANAGER);
+                    if (this.plugin.settings.calloutProviderSource === CalloutProviderSource.CALLOUT_MANAGER) {
+                        component.setValue(this.plugin.settings.calloutProviderSource);
+                    }
+                }
+            })
     }
 
     private async reloadWords() {


### PR DESCRIPTION
This pull requests adds support for the Callout Manager API, allowing Callout Manager to provide a list of callouts (and their icons/colors) to use for callout completions. It introduces a new drop-down setting to change the source for callout suggestions.

By default, Completr's `callouts.json` file will be used.

If Callout Manager is installed, a new option labelled "Callout Manager" will be available.
Selecting this option will have Completr suggest the callouts detected by Callout Manager instead.

**Screenshot:**

<img width="189" alt="image" src="https://user-images.githubusercontent.com/32112321/220236333-81c23bd9-5a9b-4751-ab5e-c32fe4fdf0fa.png">
(the `deprecated` callout is a custom callout)
